### PR TITLE
Routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS-Store
 *.gem
 *.rbc
 /.config

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source "https://rubygems.org"
 gem "sinatra", "~>1.4.7"
 gem "sinatra-contrib"
 gem "erubis"
+gem "rack-test"
+gem "minitest"
 
 ruby "2.6.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     backports (3.18.2)
     erubis (2.7.0)
+    minitest (5.14.2)
     multi_json (1.15.0)
     nio4r (2.5.4)
     puma (5.0.4)
@@ -30,7 +31,9 @@ PLATFORMS
 
 DEPENDENCIES
   erubis
+  minitest
   puma
+  rack-test
   sinatra (~> 1.4.7)
   sinatra-contrib
 

--- a/routes.rb
+++ b/routes.rb
@@ -5,7 +5,7 @@ require 'sinatra/content_for'
 
 before do
   @users = ["NDF", "Andrew", "Mr. Fish", "trvshlt", "CWK"]
-  @stats = ["running", "calories", "weigh-ins"]
+  @stats = ["running", "calories", "weigh-ins", "progress"]
 end
 
 get '/' do

--- a/test/fitness_test.rb
+++ b/test/fitness_test.rb
@@ -1,0 +1,21 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'minitest/autorun'
+require 'rack/test'
+
+require_relative '../routes'
+
+class CMSTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_summary
+    get '/summary'
+
+    assert_equal 200, last_response.status
+    assert_includes last_response.body, 'Summary to be added here.'
+  end
+end


### PR DESCRIPTION
# Adds requirements to enable testing of the application

This update includes the addition of two new gems to the Gemfile: 1) rack-test and 2) mintiest. `bundle install` must be run after the addition of new gems to the Gemfile.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran `bundle exec ruby test/fitness_test.rb` from the root project directory. The tests were able to run, which showed that testing functionality has been successfully added. Additionally, the single test added to the test file, which issues a GET request to the '/summary' route and confirms the route is behaving as currently expected, passed with no issue.

